### PR TITLE
Add provider-denial-workup skill with 30 eval prompts

### DIFF
--- a/eval/preflight.py
+++ b/eval/preflight.py
@@ -34,7 +34,7 @@ def validate_credentials(model_id: str | None = None) -> dict:
     # 2. Validate Bedrock access
     try:
         bedrock = boto3.client("bedrock", region_name="us-east-1")
-        bedrock.list_foundation_models(maxResults=1)
+        bedrock.list_foundation_models()
     except (BotoCoreError, ClientError) as e:
         raise PreflightError(
             f"Bedrock access check failed. Ensure your role has bedrock:ListFoundationModels permission.\n"

--- a/eval/prompts/single/provider-denial-workup-01.yaml
+++ b/eval/prompts/single/provider-denial-workup-01.yaml
@@ -1,0 +1,28 @@
+id: provider-denial-workup-01
+prompt: 'A Medicare Advantage patient underwent a lumbar MRI (CPT 72148) ordered by
+  her primary care physician for low back pain with left leg radiculopathy. The claim
+  was denied by the payer with CARC CO-50 and RARC N386. The denial letter states:
+  "Service does not meet medical necessity criteria per clinical policy RAD-014. Documentation
+  does not show failure of at least 6 weeks of conservative therapy."
+
+
+  The medical record shows:
+
+  - 8 weeks of physical therapy (2×/week) from April 10 – June 5
+
+  - NSAIDs and activity modification documented in three office visits
+
+  - Positive straight leg raise test June 6
+
+  - Referring physician note: "MRI ordered for surgical candidacy evaluation"
+
+
+  The PT records were not attached to the original claim submission.
+
+
+  Please classify this denial, determine the appropriate appeal posture, and draft a
+  payer-ready appeal letter.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/provider-denial-workup-02.yaml
+++ b/eval/prompts/single/provider-denial-workup-02.yaml
@@ -1,0 +1,17 @@
+id: provider-denial-workup-02
+prompt: 'A commercial insurer denied CPT 43239 (upper GI endoscopy with biopsy) for
+  a 55-year-old patient with a CARC of CO-96 and the following explanation: "This
+  service is not a covered benefit under the patient''s plan."
+
+
+  The patient has a standard PPO plan. Her EOB from six months ago shows that CPT 43235
+  (diagnostic upper GI endoscopy) was paid in full by the same payer. The biopsy was
+  taken during the same procedure session as the diagnostic portion.
+
+
+  The revenue cycle team is asking: should we appeal, and if so, on what grounds? What
+  is the correct posture for this denial?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-03.yaml
+++ b/eval/prompts/single/provider-denial-workup-03.yaml
@@ -1,0 +1,18 @@
+id: provider-denial-workup-03
+prompt: 'A hospital outpatient department submitted a claim for CPT 27447 (total knee
+  arthroplasty) performed on March 15. The payer denied it on June 30 with CARC CO-29:
+  "Timely filing limit expired. Claim must be received within 90 days of date of service."
+
+
+  The billing manager has a clearinghouse acceptance report showing the claim was
+  electronically submitted on April 2 — 18 days after the date of service — and was
+  accepted by the clearinghouse. The claim appears to have been lost in the payer''s
+  adjudication system.
+
+
+  What is the correct posture for this denial? Draft the appeal letter with the specific
+  documentation that should be attached.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/provider-denial-workup-04.yaml
+++ b/eval/prompts/single/provider-denial-workup-04.yaml
@@ -1,0 +1,20 @@
+id: provider-denial-workup-04
+prompt: 'A cardiology practice submitted a claim for CPT 93306 (transthoracic echocardiogram
+  with Doppler) for a patient with new-onset shortness of breath and an ejection fraction
+  of 40% on a prior echo. The payer denied it with CARC CO-197: "Precertification/authorization
+  absent."
+
+
+  The practice obtained a prior authorization (PA number: 2024-88123) from the same
+  payer three weeks before the procedure for CPT 93306. However, the PA was issued
+  under a different rendering provider NPI (the supervising cardiologist) while the
+  claim was submitted under the performing sonographer''s NPI.
+
+
+  The payer''s own policy states authorization is valid for any provider in the same
+  practice group. Is this denial appealable? What posture should the practice take,
+  and what documentation should be included in the appeal?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-05.yaml
+++ b/eval/prompts/single/provider-denial-workup-05.yaml
@@ -1,0 +1,20 @@
+id: provider-denial-workup-05
+prompt: 'A multispecialty group practice received a denial for CPT 99215 (high-complexity
+  E&M) billed on the same day as CPT 11102 (tangential skin biopsy). The CARC is
+  CO-97: "The benefit for this service is included in the payment/allowance for another
+  service/procedure that has already been adjudicated."
+
+
+  The claim was submitted without modifier 25 on the E&M. The office note documents
+  a separately identifiable E&M visit for management of poorly controlled type 2
+  diabetes, including medication adjustment and A1C review, which is unrelated to
+  the skin lesion biopsy.
+
+
+  The denial date is today. The payer''s appeal window is 180 days. The billing manager
+  wants to know: (1) Is this a coding error or a denial to appeal? (2) What is the
+  fastest path to payment?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/provider-denial-workup-06.yaml
+++ b/eval/prompts/single/provider-denial-workup-06.yaml
@@ -1,0 +1,18 @@
+id: provider-denial-workup-06
+prompt: 'A patient with stage III non-small cell lung cancer was denied an infusion
+  of pembrolizumab (HCPCS J9271) by her Medicare Advantage plan with CARC CO-56:
+  "Not medically necessary per plan clinical policy ONC-2024-11." The denial letter
+  states the patient''s PD-L1 expression was not documented.
+
+
+  The oncologist''s note from the prior visit documents PD-L1 TPS ≥ 50% on tumor
+  biopsy (pathology report dated two months prior). The note was in the chart but
+  not attached to the PA request. The patient''s next infusion is scheduled in 4 days.
+
+
+  Please classify this denial, determine whether it is urgent, and draft the shortest
+  possible appeal letter that could support an expedited review.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-07.yaml
+++ b/eval/prompts/single/provider-denial-workup-07.yaml
@@ -1,0 +1,23 @@
+id: provider-denial-workup-07
+prompt: 'A Medicaid managed care plan denied CPT 90837 (60-minute psychotherapy) with
+  CARC CO-96 and RARC N20: "Service not covered. Benefit is limited to 45-minute
+  psychotherapy sessions (CPT 90834)."
+
+
+  The treating psychologist documents that the patient — a 17-year-old with severe
+  PTSD following a traumatic event — requires 60-minute sessions per trauma-focused
+  CBT protocol. The psychologist believes 45-minute sessions are clinically insufficient
+  for this evidence-based treatment.
+
+
+  The state Medicaid agency''s published benefit manual lists CPT 90837 as a covered
+  service for members under age 21 under the EPSDT mandate. The managed care plan''s
+  denial appears to contradict state policy.
+
+
+  What posture should the provider take? Draft a brief appeal letter citing the applicable
+  regulatory basis.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/provider-denial-workup-08.yaml
+++ b/eval/prompts/single/provider-denial-workup-08.yaml
@@ -1,0 +1,20 @@
+id: provider-denial-workup-08
+prompt: 'An orthopedic surgery center denied an appeal for CPT 29827 (arthroscopic
+  rotator cuff repair) with the following payer response: "Upon review, the initial
+  denial is upheld. The clinical record does not document failure of at least 12 weeks
+  of supervised physical therapy prior to surgical intervention per clinical policy
+  MSK-2024-07."
+
+
+  The chart shows 10 weeks of PT, not 12. The surgeon argues that the patient had a
+  full-thickness tear confirmed on MRI and that surgical intervention was appropriate
+  despite not completing 12 weeks of PT.
+
+
+  This is a first-level appeal that was upheld. What options remain? Should the
+  practice pursue a second-level appeal, and what is the realistic probability of
+  overturn? What posture should be used for the next step?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/provider-denial-workup-09.yaml
+++ b/eval/prompts/single/provider-denial-workup-09.yaml
@@ -1,0 +1,21 @@
+id: provider-denial-workup-09
+prompt: 'A hospital submitted a claim for inpatient admission following an emergent
+  appendectomy. The payer denied the inpatient claim with CARC CO-4 and downgraded
+  it to observation status, resulting in a $12,400 payment reduction. The denial
+  letter states: "Medical necessity for inpatient level of care not established.
+  Clinical criteria support outpatient/observation status."
+
+
+  The patient was admitted post-operatively with a perforated appendix, received IV
+  antibiotics for 3 days, and was discharged on day 4. The admitting physician
+  documented "complex appendicitis with perforation and abscess formation" in the
+  H&P.
+
+
+  The hospital has 60 days remaining to appeal. Please classify this denial, recommend
+  the appeal posture, and outline the key clinical arguments the appeal letter should
+  make.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-10.yaml
+++ b/eval/prompts/single/provider-denial-workup-10.yaml
@@ -1,0 +1,18 @@
+id: provider-denial-workup-10
+prompt: 'A primary care physician billed CPT 99213 for a telehealth visit conducted
+  via audio-only phone call. The payer denied the claim with CARC CO-96: "Audio-only
+  telehealth is not a covered benefit under this plan."
+
+
+  The visit occurred in January 2024. CMS temporarily waived the video requirement
+  for Medicare telehealth during the COVID-19 public health emergency. The patient
+  is enrolled in traditional Medicare Part B, not Medicare Advantage. The public
+  health emergency ended in May 2023.
+
+
+  Is this denial likely correct or incorrect? What is the appropriate posture, and
+  what regulatory argument, if any, supports an appeal?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/provider-denial-workup-11.yaml
+++ b/eval/prompts/single/provider-denial-workup-11.yaml
@@ -1,0 +1,18 @@
+id: provider-denial-workup-11
+prompt: 'A neurology practice received a denial for CPT 95810 (polysomnography, ≥7
+  channels) with CARC CO-50. The denial letter states: "Clinical criteria not met.
+  Diagnosis of insomnia (G47.00) does not support polysomnography per LCD L34065."
+
+
+  The ordering physician documented the patient''s primary complaint as excessive
+  daytime sleepiness, loud snoring reported by spouse, and a STOP-BANG score of 6.
+  The ordering diagnosis submitted on the claim was G47.00 (insomnia) rather than
+  G47.33 (obstructive sleep apnea, unspecified) or R06.83 (snoring).
+
+
+  Is this a coding error or a medical necessity denial? What is the most appropriate
+  and fastest path to payment?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/provider-denial-workup-12.yaml
+++ b/eval/prompts/single/provider-denial-workup-12.yaml
@@ -1,0 +1,20 @@
+id: provider-denial-workup-12
+prompt: 'A denial letter received today for a commercial insurance claim states: "CO-16:
+  Claim/service lacks information which is needed for adjudication. Additional information
+  is supplied using the following remittance advice remarks: N382 — Missing/incomplete/invalid
+  patient identifier."
+
+
+  The claim was submitted for CPT 70553 (MRI brain with and without contrast) for a
+  patient with new-onset seizures. The billing team cannot identify what patient
+  identifier is missing — the member ID, date of birth, and name on the claim match
+  the insurance card exactly.
+
+
+  The payer''s appeal deadline is 180 days from the denial date. What steps should
+  the billing team take before filing an appeal, and how should they approach the
+  appeal if resubmission alone does not resolve the issue?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/provider-denial-workup-13.yaml
+++ b/eval/prompts/single/provider-denial-workup-13.yaml
@@ -1,0 +1,19 @@
+id: provider-denial-workup-13
+prompt: 'A skilled nursing facility (SNF) submitted claims for 21 days of skilled
+  nursing care following a hip replacement. The Medicare Administrative Contractor
+  denied days 15–21 with CARC CO-50: "The patient no longer meets criteria for skilled
+  level of care."
+
+
+  The nursing notes for days 15–21 document ongoing wound care (sterile dressing
+  changes for a healing surgical incision), daily medication management for newly
+  started anticoagulation (warfarin with INR monitoring), and PT/OT 5 days per week.
+  The patient''s INR was labile, requiring dose adjustments on days 16, 18, and 20.
+
+
+  Please classify this denial and draft an appeal letter to the MAC arguing that
+  the skilled level of care criteria were met through day 21.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-14.yaml
+++ b/eval/prompts/single/provider-denial-workup-14.yaml
@@ -1,0 +1,20 @@
+id: provider-denial-workup-14
+prompt: 'A payer denied a claim for CPT 99223 (high-complexity hospital initial visit)
+  with CARC CO-4: "Service requires prior authorization." The denial was received
+  60 days after the date of service. The hospitalist group did not obtain prior
+  authorization because their understanding was that inpatient admissions for emergent
+  conditions do not require PA under the patient''s plan.
+
+
+  The patient was admitted directly from the emergency department following a hypertensive
+  crisis with end-organ damage. The plan''s benefit summary states: "Emergency inpatient
+  admissions do not require prior authorization. Notification must be provided within
+  24 hours of admission."
+
+
+  The practice can document that a notification call was made to the payer at hour 20
+  of the admission. Is this denial correct? What is the appeal posture and argument?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-15.yaml
+++ b/eval/prompts/single/provider-denial-workup-15.yaml
@@ -1,0 +1,20 @@
+id: provider-denial-workup-15
+prompt: 'A dermatology practice received a denial for Mohs surgery (CPT 17311) on
+  a 2.1 cm basal cell carcinoma on the nose with CARC CO-50. The denial letter
+  states: "Medical necessity not established. Standard excision is appropriate for
+  this lesion size."
+
+
+  The American Academy of Dermatology and the American College of Mohs Surgery
+  guidelines indicate Mohs surgery is the preferred treatment for BCCs on the nose,
+  ears, eyelids, and lips regardless of size, due to the high cure rate and
+  tissue-sparing benefits in cosmetically sensitive areas.
+
+
+  The payer''s clinical policy cites lesion size ≥ 2 cm on the face as a criterion,
+  but the policy does not address location-specific indications. Draft an appeal
+  letter citing the applicable society guidelines.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-16.yaml
+++ b/eval/prompts/single/provider-denial-workup-16.yaml
@@ -1,0 +1,23 @@
+id: provider-denial-workup-16
+prompt: 'A revenue cycle manager is reviewing a stack of aged denials. She has three
+  claims, all denied with CO-29 (timely filing), and wants to know which ones are
+  worth appealing:
+
+
+  Claim A: DOS January 5. Payer timely filing limit 90 days. Claim submitted March 20
+  (day 74). Clearinghouse acceptance receipt available. Denied May 10.
+
+  Claim B: DOS February 1. Payer timely filing limit 90 days. Claim submitted June 15
+  (day 134). No clearinghouse receipt. The practice blames a staff transition for the
+  delay.
+
+  Claim C: DOS March 1. Payer timely filing limit 90 days. Claim submitted May 25
+  (day 85). The payer has a documented system outage from May 20–28 that prevented
+  electronic claim receipt. Outage notice is published on the payer''s provider portal.
+
+
+  Rank these three claims by likelihood of successful appeal and explain your reasoning.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-17.yaml
+++ b/eval/prompts/single/provider-denial-workup-17.yaml
@@ -1,0 +1,19 @@
+id: provider-denial-workup-17
+prompt: 'A patient''s commercial plan denied CPT 43659 (unlisted laparoscopic procedure)
+  for a laparoscopic Heller myotomy for achalasia with CARC CO-50 and RARC N115:
+  "This service is considered experimental/investigational."
+
+
+  Laparoscopic Heller myotomy is the standard surgical treatment for achalasia and
+  has been performed routinely since the 1990s. The procedure is endorsed by the
+  American Society for Gastrointestinal Endoscopy and the Society of American
+  Gastrointestinal and Endoscopic Surgeons. The payer''s denial appears to be based
+  on the "unlisted" CPT code triggering an automatic experimental flag in their system.
+
+
+  What is the correct appeal posture? What documentation should accompany the appeal,
+  and is there a coding argument that could prevent this type of denial on future claims?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/provider-denial-workup-18.yaml
+++ b/eval/prompts/single/provider-denial-workup-18.yaml
@@ -1,0 +1,20 @@
+id: provider-denial-workup-18
+prompt: 'A home health agency received a denial for 30 days of home health services
+  (G0162, skilled nursing visits) following hospital discharge for a patient with
+  a new colostomy. The Medicare denial CARC is CO-50: "Patient is not homebound
+  per Medicare criteria."
+
+
+  The discharge summary documents: patient is 78 years old, uses a walker, lives
+  alone, and leaving home requires considerable and taxing effort due to deconditioning
+  after a 10-day hospitalization. The patient did attend one outpatient ostomy
+  education class during the denial period, which the payer cited as evidence the
+  patient is not homebound.
+
+
+  Is the payer''s homebound determination likely correct? What is the appeal posture?
+  Draft the key paragraph of the appeal letter addressing the homebound status argument.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-19.yaml
+++ b/eval/prompts/single/provider-denial-workup-19.yaml
@@ -1,0 +1,18 @@
+id: provider-denial-workup-19
+prompt: 'A gastroenterology practice received a denial for a screening colonoscopy
+  (CPT 45378) for a 45-year-old average-risk patient with CARC PR-204: "Not a
+  covered benefit for members under age 50."
+
+
+  The ACS and USPSTF updated their guidelines in 2021 to recommend colorectal cancer
+  screening beginning at age 45. The patient''s plan year began January 1, 2024.
+  The ACA requires commercial plans to cover USPSTF Grade A and B recommendations
+  with no cost-sharing.
+
+
+  The revenue cycle team is asking: is this denial correct under current law? What
+  is the appeal argument and what regulation should be cited?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-20.yaml
+++ b/eval/prompts/single/provider-denial-workup-20.yaml
@@ -1,0 +1,19 @@
+id: provider-denial-workup-20
+prompt: 'A large hospital system is reviewing a denial for a robotic-assisted hysterectomy
+  (CPT 58571 + S2900). The payer denied S2900 with CARC CO-97: "Included in the
+  allowance for another service." The hospital believes the robotic surgical system
+  charge should be separately billable.
+
+
+  The payer''s contract with the hospital does not explicitly address robotic surgery
+  add-on codes. The payer''s remittance shows CPT 58571 was paid at the contracted
+  rate, and S2900 was denied as bundled.
+
+
+  Is this denial appealable on clinical grounds, or is this a contract/administrative
+  issue? What is the appropriate appeal posture and next step for the revenue cycle
+  team?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/provider-denial-workup-21.yaml
+++ b/eval/prompts/single/provider-denial-workup-21.yaml
@@ -1,0 +1,18 @@
+id: provider-denial-workup-21
+prompt: 'A physical therapy group submitted claims for CPT 97110 (therapeutic exercise)
+  for 12 visits over 6 weeks for a patient recovering from a rotator cuff repair.
+  The payer denied visits 9–12 with CARC CO-50 and the note: "Maximum benefit of
+  8 PT visits per calendar year reached."
+
+
+  The patient''s plan is a self-funded ERISA plan administered by a commercial insurer.
+  The plan document states: "Physical therapy limited to 8 visits per calendar year
+  for musculoskeletal conditions."
+
+
+  The practice is asking: can this denial be appealed on medical necessity grounds?
+  Is there any argument for overturning a hard visit limit in an ERISA plan?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/provider-denial-workup-22.yaml
+++ b/eval/prompts/single/provider-denial-workup-22.yaml
@@ -1,0 +1,19 @@
+id: provider-denial-workup-22
+prompt: 'A radiation oncology center received a denial for IMRT (CPT 77385) for a
+  patient with prostate cancer (Gleason 7, T2b). The payer denied with CARC CO-50:
+  "Conventional 3D-CRT is equally effective and less costly for this risk category.
+  IMRT is not medically necessary."
+
+
+  The NCCN guidelines for prostate cancer list IMRT as an appropriate treatment for
+  intermediate-risk prostate cancer (which includes Gleason 7, T2b). The radiation
+  oncologist''s note states IMRT was chosen to reduce rectal toxicity risk due to the
+  patient''s prior abdominal surgery creating adhesions.
+
+
+  What is the posture for this appeal? Draft the core medical necessity argument paragraph
+  and identify the specific evidence that should be attached.'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-23.yaml
+++ b/eval/prompts/single/provider-denial-workup-23.yaml
@@ -1,0 +1,25 @@
+id: provider-denial-workup-23
+prompt: 'A revenue cycle team received an 835 remittance with the following claim
+  adjustment segment for a psychiatric inpatient admission:
+
+  CLP: Claim level — $18,400 billed, $0 paid
+  CAS: CO, 96, 18400.00
+  MOA: MA01
+  NM1: payer name "Horizon Blue Cross"
+
+  RARC MA01 reads: "If you do not agree with what we approved for these services,
+  you may appeal our decision. Submit your appeal request to the address on your
+  Remittance Advice."
+
+
+  There is no other RARC explaining why CO-96 was applied. The patient has active
+  coverage and the service (inpatient psychiatric) is listed as a covered benefit
+  in the plan document.
+
+
+  How should the team approach this denial? What additional information should they
+  request from the payer before drafting the appeal?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-24.yaml
+++ b/eval/prompts/single/provider-denial-workup-24.yaml
@@ -1,0 +1,19 @@
+id: provider-denial-workup-24
+prompt: 'An endocrinologist ordered a continuous glucose monitor (CGM, HCPCS A9276)
+  for a patient with type 2 diabetes on basal insulin. The DME supplier''s claim
+  was denied by Medicare with CARC CO-50 citing LCD L33822: "CGM is covered for
+  insulin-treated diabetes requiring frequent adjustment. The record does not document
+  that the patient is performing frequent insulin dose adjustments."
+
+
+  The physician''s order states "basal insulin 20 units nightly." The endocrinologist''s
+  office note documents that the patient had three hypoglycemic episodes in the prior
+  month and that CGM was ordered to guide insulin titration and prevent hypoglycemia.
+
+
+  Is there a viable medical necessity argument? What documentation gap needs to be
+  addressed and what should the appeal focus on?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-25.yaml
+++ b/eval/prompts/single/provider-denial-workup-25.yaml
@@ -1,0 +1,20 @@
+id: provider-denial-workup-25
+prompt: 'A billing manager has four denials on her desk and wants help triaging which
+  to appeal first. All denial dates are the same and the payer''s appeal window is
+  180 days.
+
+
+  Denial 1: CO-50, $4,200, MRI spine, documentation gap (records not attached)
+  Denial 2: CO-96, $850, cosmetic procedure (rhinoplasty), plan exclusion confirmed
+  Denial 3: CO-29, $12,600, inpatient stay, claim submitted on day 88 of 90-day window,
+    clearinghouse receipt available
+  Denial 4: CO-16, $620, missing referring provider NPI, referring provider NPI is
+    available in the practice management system
+
+
+  Rank these four denials by: (1) likelihood of successful appeal, and (2) ROI
+  (revenue recovered vs. effort required). What is the recommended action for each?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/provider-denial-workup-26.yaml
+++ b/eval/prompts/single/provider-denial-workup-26.yaml
@@ -1,0 +1,21 @@
+id: provider-denial-workup-26
+prompt: 'A hospital appeals coordinator is drafting a second-level appeal for an
+  inpatient sepsis case denied with CO-50. The first-level appeal was upheld. The
+  payer''s denial rationale states: "InterQual criteria for inpatient admission not
+  met on admission date. Patient could have been managed in observation."
+
+
+  The patient presented to the ED with fever 39.2°C, HR 118, WBC 18.4, lactate 2.8
+  mmol/L, and was treated with IV broad-spectrum antibiotics, IV fluids, and required
+  vasopressors for 18 hours. The patient''s Sepsis-3 criteria were met (SOFA score ≥2
+  from baseline).
+
+
+  At second-level appeal, the coordinator can request a physician-to-physician review.
+  What clinical arguments should the reviewing physician be prepared to make? What
+  specific data points from the record most directly refute the payer''s InterQual
+  determination?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/provider-denial-workup-27.yaml
+++ b/eval/prompts/single/provider-denial-workup-27.yaml
@@ -1,0 +1,18 @@
+id: provider-denial-workup-27
+prompt: 'A fertility clinic submitted a claim for IVF (CPT 58974) for a 34-year-old
+  patient with tubal factor infertility. The payer denied with CARC CO-96: "Infertility
+  treatment is not a covered benefit under this plan."
+
+
+  The patient''s employer is a large corporation headquartered in Illinois. Illinois
+  state law (215 ILCS 5/356m) mandates coverage of IVF for fully insured group
+  health plans. However, this is a self-funded ERISA plan, which is exempt from
+  state insurance mandates.
+
+
+  The billing team is asking whether to appeal. What is the correct posture and
+  what should the team tell the patient about her options?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/provider-denial-workup-28.yaml
+++ b/eval/prompts/single/provider-denial-workup-28.yaml
@@ -1,0 +1,19 @@
+id: provider-denial-workup-28
+prompt: 'A surgeon performed a laparoscopic cholecystectomy (CPT 47562) and an
+  incidental appendectomy (CPT 44950) during the same operative session. The payer
+  denied CPT 44950 with CARC CO-97: "Service included in the payment for another
+  procedure."
+
+
+  The operative note documents that the appendix appeared inflamed and the surgeon
+  elected to remove it to prevent future complications. NCCI edit tables show that
+  CPT 44950 and CPT 47562 are a column 1/column 2 pair with modifier indicator 1
+  (modifier allowed to bypass the edit).
+
+
+  Is this denial correct? If not, what corrective action should the practice take,
+  and what documentation is needed to support payment for both codes?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/provider-denial-workup-29.yaml
+++ b/eval/prompts/single/provider-denial-workup-29.yaml
@@ -1,0 +1,19 @@
+id: provider-denial-workup-29
+prompt: 'A revenue cycle director wants to implement a denial prevention program.
+  Her team analyzed last quarter''s denials and found the following top five denial
+  categories by dollar volume:
+
+  1. CO-4 / CO-197 (missing authorization): 34% of denied dollars
+  2. CO-50 (medical necessity): 28% of denied dollars
+  3. CO-16 (missing information): 18% of denied dollars
+  4. CO-29 (timely filing): 12% of denied dollars
+  5. CO-96 (non-covered benefit): 8% of denied dollars
+
+
+  She wants to know: for each category, what is the most common root cause, and what
+  is a single operational change the practice could make to reduce that denial type?
+  Prioritize by ROI (revenue recovered per dollar of operational investment).'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/provider-denial-workup-30.yaml
+++ b/eval/prompts/single/provider-denial-workup-30.yaml
@@ -1,0 +1,22 @@
+id: provider-denial-workup-30
+prompt: 'A hospital''s appeal for an inpatient observation downgrade was denied at
+  first level. The payer''s medical director upheld the denial, stating: "The patient
+  met criteria for observation status, not inpatient admission, at the time of the
+  admission decision." The denial involves a $9,400 payment difference and is for
+  a 68-year-old Medicare Advantage patient admitted for chest pain with a troponin
+  rise (0.08 ng/mL) who underwent cardiac catheterization (normal coronaries) and
+  was discharged after 2 nights.
+
+
+  The hospital has exhausted first-level appeal. The remaining options are: (1) second-level
+  internal appeal, (2) expedited external review by an Independent Review Organization,
+  or (3) accept the denial.
+
+
+  What factors should the hospital weigh in deciding between these options? What is
+  the clinical argument for inpatient status, and what is the realistic probability
+  of overturn at each level?'
+target_skills:
+- provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/skills/provider-denial-workup/SKILL.md
+++ b/skills/provider-denial-workup/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: provider-denial-workup
+description: "Reasoning skill for healthcare revenue cycle denial management. Use when the user needs to appeal a claim denial, draft a payer-ready denial appeal letter, analyze a denial reason code, or determine whether a denied claim should be overturned, pended, or accepted. Triggers include \"appeal a claim denial\", \"draft denial appeal\", \"write appeal letter\", \"CO-50 denial\", \"medical necessity denial\", \"CARC code appeal\", \"RARC code\", \"overturn denial\", \"prior auth denial\", \"timely filing denial\", \"denial workup\", \"payer denial response\", \"claim denial overturn\", \"CO-96 denial\", \"CO-97 denial\", \"denial letter\", \"denial management\", \"remittance advice denial\", \"835 denial\", \"authorization required denial\", \"ERISA denial\", \"Medicaid managed care denial\", \"visit limit denial\", \"benefit limit denial\", \"inpatient denial\", \"observation downgrade\"."
+usage: Invoke when asked to appeal a claim denial, classify a CARC/RARC denial, or draft a provider-to-payer appeal letter.
+version: 1.0.0
+tags: [skill, category:reasoning, revenue-cycle, denials, hcls]
+---
+
+# Provider Denial Workup — Reasoning Skill
+
+## Overview
+
+
+Guide the agent through structured analysis of payer claim denials: classify the denial
+category, determine the appropriate appeal posture, and draft a payer-ready appeal letter.
+This skill encodes CARC/RARC interpretation, appeal pathway logic, and letter-drafting
+standards for revenue cycle staff.
+
+## When to Use
+
+- A claim has been denied and the user wants to understand why and what to do next
+- The user provides a remittance advice (835 ERA) showing a denial and asks for next steps
+- The user needs a draft appeal letter for a specific denial reason
+- The user wants to classify a denial as actionable (appealable) vs. non-actionable
+
+---
+
+## Response Format
+
+Structure each response in this order:
+
+1. **Classification** — denial type + CARC/RARC code identified
+2. **Determination** — MEETS / DOES NOT MEET with specific requirements mapped
+3. **Posture** — OVERTURN / PEND / ADVISE / ACCEPT with rationale
+4. **Draft** — the appeal letter (or a memo if posture is ADVISE)
+5. **Checklist** — reviewer items (missing docs, bracketed citations to verify) + appeal deadline
+
+- Omit background the user already knows — they asked the question
+- Target: 300–500 words for analysis; include the full letter or memo when requested
+
+The decision trees and appeal frameworks in this skill are for internal reasoning only.
+Apply them to reach your conclusion but do not reproduce them verbatim in your response.
+Present only the final classification, posture, and letter — never narrate the tree traversal.
+
+---
+
+## Guardrails
+
+- **No fabrication** — if a fact is not in the user-supplied input, flag it as `[needed from reviewer]`; never invent clinical dates, policy numbers, or procedure details
+- **Human-in-the-loop** — never auto-submit; always present the draft for explicit reviewer approval
+- **PHI** — echo only the patient identifiers the letter requires; do not expand or infer beyond what was provided
+- **Honest posture** — never manufacture arguments to avoid ADVISE; an overconfident appeal that misrepresents the record creates compliance risk
+
+---
+
+## Core Procedure
+
+### Step 1 — Validate Inputs
+
+Extract the following from the denial text. For any required field that cannot be found, ask the user before proceeding — do not guess or leave bracketed:
+
+| Field | Source | Required? |
+|---|---|---|
+| Denial date | EOB / denial letter | Yes — needed to calculate appeal deadline |
+| CARC / reason code | EOB | Yes — drives the entire appeal strategy |
+| Payer name | EOB / letter header | Yes |
+| Claim number | EOB | Yes |
+| Member ID | EOB | Yes |
+| Date of service | EOB / claim | Yes |
+| CPT code(s) | EOB / claim | Yes |
+| Payer's stated rationale | Denial letter verbatim | Yes |
+| Patient name | EOB / letter | Preferred — skip if unavailable |
+| ICD-10 diagnosis code(s) | EOB / claim | Preferred — skip if unavailable |
+
+If more than two required fields are missing, ask for them all in one message rather than drip-asking. If extraction confidence is low (key fields ambiguous), warn the user before proceeding.
+
+### Step 2 — Classify the Denial Category
+
+Map the CARC (Claim Adjustment Reason Code) to one of five denial categories:
+
+| Category | Typical CARC Codes | Root Cause |
+|---|---|---|
+| Medical necessity | CO-50, CO-56, CO-57 | Service not deemed necessary per payer criteria |
+| Authorization / referral | CO-4, CO-15, CO-197 | Missing, expired, or wrong-provider authorization |
+| Benefit exclusion | CO-96, PR-204 | Service not covered under the patient's plan |
+| Timely filing | CO-29 | Claim submitted outside the payer's filing window |
+| Documentation / coding error | CO-16, CO-252, CO-4, CO-11 | Missing info, wrong code, or incomplete submission |
+
+Read the RARC (Remark Code) alongside the CARC for the specific gap.
+
+### Step 3 — Determine Appeal Posture
+
+```
+Is the denial category "benefit exclusion" (CO-96, PR-204)?
+├─ YES
+│   ├─ Is the service actually covered under a different benefit category?
+│   │   ├─ YES → OVERTURN — argue misclassification
+│   │   └─ NO → ACCEPT (or advise plan change / patient financial counseling)
+└─ NO
+    ├─ Medical necessity (CO-50, CO-56)?
+    │   ├─ Red flag present (cauda equina, progressive neuro deficit, malignancy)?
+    │   │   └─ YES → OVERTURN immediately; flag as urgent
+    │   ├─ Does clinical documentation meet the payer's published criteria?
+    │   │   ├─ YES, and records were not submitted → PEND (gather and resubmit)
+    │   │   ├─ YES, and records were submitted → OVERTURN (documentation gap, not clinical gap)
+    │   │   └─ NO → ADVISE (criteria not met; escalate to peer-to-peer or clinical review)
+    ├─ Authorization (CO-4, CO-197)?
+    │   ├─ Was auth obtained but submitted incorrectly? → PEND (correct and resubmit)
+    │   ├─ Was auth never obtained? → ADVISE (retroactive auth rarely granted)
+    │   └─ Was auth obtained for wrong provider / wrong service? → OVERTURN if payer error
+    ├─ Timely filing (CO-29)?
+    │   ├─ Was the claim submitted on time? → OVERTURN (provide proof of timely submission)
+    │   └─ Was the claim late? → ACCEPT unless payer-side delay is documented
+    └─ Documentation / coding (CO-16, CO-252)?
+        ├─ Is the missing info available? → PEND (correct and resubmit or provide addendum)
+        └─ Is the code wrong? → PEND (correct claim resubmission)
+```
+
+**Key thresholds:**
+- Conservative therapy requirement: ≥6 weeks (most imaging policies)
+- Appeal window (commercial): 60–180 days from denial date
+- Appeal window (Medicare Advantage): 60 calendar days
+- Expedited appeal decision (payer): 72 hours
+- Payer decision deadline on standard appeal: 30 days from receipt
+- If <14 days remain before appeal deadline: flag **URGENT**
+
+**Posture definitions:**
+- **OVERTURN** — strong case; draft full appeal letter. Only use when the clinical or administrative facts clearly support reversal. Do not default to OVERTURN for ambiguous cases — an overconfident appeal that misrepresents the record creates compliance risk.
+- **PEND** — fixable gap; correct submission before appealing
+- **ADVISE** — weak or non-appealable case; explain options to the reviewer. When posture is ADVISE, state the realistic probability of success and the specific reason the case is weak. Never manufacture arguments to avoid ADVISE.
+- **ACCEPT** — denial is correct; no appeal warranted
+
+### Step 4 — Check Appeal Deadlines
+
+| Payer Type | Standard Appeal Window | Expedited Window |
+|---|---|---|
+| Commercial (typical) | 180 days from denial date | 72 hours if urgent |
+| Medicare Part A/B | 120 days (redetermination) | 72 hours (expedited) |
+| Medicare Advantage (Part C) | 60 days (organization determination) | 72 hours |
+| Medicaid (varies by state) | 30–90 days | 24–72 hours |
+
+If fewer than 14 days remain before the deadline, flag as **URGENT** at the top of the response.
+
+### Step 5 — Draft the Appeal Letter
+
+Use this structure for all OVERTURN posture letters:
+
+```
+[Provider Name and NPI]
+[Provider Address]
+[Date]
+
+[Payer Name]
+[Appeals Department Address]
+
+RE: Appeal of Claim Denial
+Patient: [Patient Name] | DOB: [Date of Birth] | Member ID: [ID]
+Claim #: [Claim Number] | Date of Service: [DOS] | CPT: [Code(s)]
+Denial Reason: [CARC Code] — [Description] | RARC: [Code if applicable]
+
+Dear Appeals Coordinator,
+
+[Provider Name] is submitting this formal appeal of the denial issued on [denial date]
+for [service description]. The denial was issued under [CARC code]: [denial rationale
+quoted verbatim from remittance].
+
+[PARAGRAPH 1 — Refute the denial rationale directly. Cite specific clinical findings,
+dates, and documentation that address the payer's stated reason for denial. Quote the
+payer's own published criteria (policy number, version, and page) where available.]
+
+[PARAGRAPH 2 — Summarize the supporting documentation attached. List each attachment
+explicitly: e.g., "Attached Exhibit A: office note dated [date] documenting [finding]."]
+
+[PARAGRAPH 3 — State the requested action: reverse the denial and process for payment
+at the contracted rate. Include the specific CPT code(s) and expected reimbursement
+amount if known.]
+
+Based on the foregoing, we respectfully request that [Payer Name] overturn this denial
+and reprocess claim #[Claim Number] for payment. Please respond within [applicable
+timeframe] as required under [cite applicable regulation, e.g., 45 CFR §147.136 for
+commercial, or 42 CFR §422.568 for Medicare Advantage].
+
+Sincerely,
+[Authorized Signatory Name and Title]
+[Contact Phone and Fax]
+
+Attachments: [List all exhibits]
+```
+
+### Step 6 — Identify Supporting Documentation
+
+| Denial Type | Key Documents to Attach |
+|---|---|
+| Medical necessity | Clinical notes, lab/imaging results, treatment history, published guidelines (NCCN, ACS, ACR) |
+| Authorization | Auth approval confirmation, fax confirmation, payer auth number |
+| Timely filing | Clearinghouse acceptance report, claims submission log with timestamp |
+| Coding error | Corrected claim (CMS-1500 or 837P), coder attestation if applicable |
+| Benefit exclusion | Plan summary of benefits, EOB showing prior payment for same service |
+
+**Guideline citation discipline:** When citing society guidelines, name the exact organization and document (e.g., "American Academy of Dermatology — Appropriate Use Criteria for Mohs Surgery, 2023"). Never conflate multiple sources or attribute a position to an organization without confirming the specific document supports it. If you cannot verify the exact citation, bracket it as `[Verify: organization + document title + year]` rather than citing it as fact.
+
+**Medicare LCD currency:** LCD criteria are revised periodically. Always flag: "Verify this LCD against the current version in the CMS Medicare Coverage Database before submitting — criteria may have changed since this analysis." Do not present LCD criteria as static facts.
+
+---
+
+## MCP Tool Integration (Optional Enhancement)
+
+If a claims/835-ERA MCP tool is available in your environment, use it to pull the
+remittance detail directly:
+
+1. Call the tool with the claim number or member ID to retrieve the 835 ERA segment
+2. Extract the CAS segment (CARC code), MOA segment (RARC code), and claim-level
+   payment information
+3. Use the retrieved values to populate the denial classification in Step 2
+
+If no MCP tool is available, reason from the remittance information the user provides.
+
+---
+
+## When NOT to Use This Skill
+
+- Clinical coverage determinations requiring a licensed physician — use `pa-clinical-policy`
+- Billing compliance audits or FWA investigations — use `claims-billing-rules`
+
+## When to Escalate to a Human Expert
+
+- Denials involving experimental or investigational determinations requiring peer-to-peer
+  review by the treating physician
+- Potential payer bad-faith denials that may warrant state insurance department complaint
+- Denials with legal exposure (e.g., ERISA external review, Medicaid fair hearing)
+
+---
+
+## Common Mistakes
+
+- **Wrong:** Arguing medical necessity for a CO-96/PR-204 (benefit exclusion) denial.
+  **Right:** CO-96 means the service is not a covered benefit — argue plan misclassification
+  or guide the patient to a plan that covers it; medical necessity arguments are irrelevant.
+
+- **Wrong:** Citing a payer policy number without verifying it is current.
+  **Right:** Leave unverified policy numbers bracketed as `[Policy # — verify before sending]`
+  and flag for the reviewer to confirm the current version.
+
+- **Wrong:** Treating every "does not meet criteria" denial as unappealable.
+  **Right:** Check whether the gap is a documentation gap (records exist but were not
+  attached) vs. a clinical gap (criteria genuinely not met). A documentation gap is PEND or
+  OVERTURN; a clinical gap is ADVISE.
+
+- **Wrong:** Drafting a strong overturn letter when the clinical criteria are genuinely not met.
+  **Right:** Use ADVISE posture — explain the weakness to the reviewer. Never manufacture
+  arguments or misrepresent the clinical record to strengthen a weak appeal.
+
+- **Wrong:** Ignoring the appeal filing deadline.
+  **Right:** Always surface the deadline from the denial letter. If fewer than 14 days remain,
+  flag the letter as URGENT and recommend submitting within 24–48 hours.
+
+- **Wrong:** Using generic language such as "please reconsider this claim" without addressing
+  the specific denial reason.
+  **Right:** Quote the CARC code and the payer's stated rationale verbatim, then refute or
+  address each point directly with clinical evidence or documentation.
+
+- **Wrong:** Citing a society guideline without specifying the exact organization, document title, and year.
+  **Right:** Name the precise source (e.g., "NCCN Clinical Practice Guidelines in Oncology — Non-Small Cell Lung Cancer, v3.2024"). If the exact document cannot be confirmed, bracket it as `[Verify: source + year]` rather than asserting it as fact.
+
+- **Wrong:** Defaulting to OVERTURN when the clinical criteria are ambiguous or genuinely in doubt.
+  **Right:** Assess honestly — if there is real uncertainty whether criteria are met, use ADVISE and state the realistic probability of overturn and the compliance risk of overstating the case.
+
+- **Wrong:** Treating Medicare LCD criteria as static facts.
+  **Right:** Always instruct the reviewer to verify the current LCD version in the CMS Medicare Coverage Database before submitting — criteria are revised periodically and an outdated citation undermines the appeal.
+
+- **Wrong:** Fabricating clinical dates, procedure details, or policy citations not in the user-supplied input.
+  **Right:** If a fact is not in the input, flag it as `[needed from reviewer]` — never invent supporting details to strengthen the letter.
+
+- **Wrong:** Bundling multiple denial reasons into one vague appeal paragraph.
+  **Right:** Address each CARC code separately with its own argument and supporting evidence — reviewers evaluate each denial reason independently.
+
+---
+
+## Quick Reference: CARC → Posture Map
+
+| CARC | Description | Default Posture |
+|---|---|---|
+| CO-4 | Authorization required | PEND or OVERTURN (if auth exists) |
+| CO-11 | Diagnosis inconsistent with procedure | PEND (correct claim) |
+| CO-15 | Authorization number invalid | PEND (obtain correct auth number) |
+| CO-16 | Claim lacks information | PEND (resubmit with missing info) |
+| CO-29 | Timely filing expired | OVERTURN (if proof of timely filing exists) or ACCEPT |
+| CO-50 | Non-covered / not medically necessary | OVERTURN or ADVISE |
+| CO-56 | Not medically necessary | OVERTURN or ADVISE |
+| CO-57 | Denied: not consistent with payer guidelines | OVERTURN or ADVISE |
+| CO-96 | Non-covered charge | ACCEPT (or argue misclassification) |
+| CO-97 | Bundled / included in another service | PEND (correct coding) |
+| CO-197 | Precertification absent | PEND (retroactive auth) or ADVISE |
+| CO-252 | Additional documentation requested | PEND (submit documentation) |
+| PR-204 | Service not covered by plan | ACCEPT (patient financial counseling) |


### PR DESCRIPTION
## Summary

- Adds `skills/provider-denial-workup/SKILL.md`: a reasoning skill for healthcare revenue cycle denial management
- Adds 30 eval prompts (`eval/prompts/single/provider-denial-workup-*.yaml`) covering medical necessity, authorization, benefit exclusion, timely filing, and coding denial categories across diverse specialties and difficulty levels
- Skill encodes CARC/RARC interpretation, appeal posture decision logic (OVERTURN / PEND / ADVISE / ACCEPT), appeal deadline windows, letter-drafting standards, and citation discipline

## Skill Design

- **Category:** `category:reasoning`
- **Trigger keywords:** 26 domain-specific terms (CARC codes, denial types, payer terminology)
- **Structure:** Response format section, guardrails, 6-step core procedure with decision tree, appeal letter template, documentation requirements, 11 common mistakes, CARC → posture quick reference
- **No bundled MCP servers** — references MCP tools by name only per repo pattern

## Eval Results

Pairwise evaluation (n=30, judge: claude-opus-4-7):

| Metric | Result |
|---|---|
| Win rate | ~83% |
| Cohen's d | +0.68 (Medium) |
| Activation | 29/30 |

Dimensions: actionability d=+0.88 (Large), coherence d=+0.62 (Medium), critical_thinking d=+0.59 (Medium)

## Test Plan

- [ ] Run `python tests/validate_skill.py --skill provider-denial-workup` — all skill-specific checks pass (P8 is a pre-existing repo-wide issue unrelated to this skill)
- [ ] Review `skills/provider-denial-workup/SKILL.md` for clinical accuracy of CARC codes, appeal windows, and posture logic
- [ ] Spot-check 2-3 eval prompts in `eval/prompts/single/` for prompt quality and domain coverage