### PR TITLE
Add coordination-of-benefits reasoning skill

### DIFF
--- a/eval/prompts/cross/cob-denial-workup-01.yaml
+++ b/eval/prompts/cross/cob-denial-workup-01.yaml
@@ -1,0 +1,16 @@
+id: cob-denial-workup-01
+prompt: >
+  A 61-year-old patient is on Medicare due to disability (SSDI for 4 years) and is
+  also covered under her employer's group health plan. The employer has 80 employees.
+  A claim for lumbar spinal fusion ($42,000) was submitted to the employer GHP as
+  primary and Medicare as secondary. Medicare paid $8,400 as secondary. The GHP has
+  now issued a CO-22 denial, stating that Medicare should be primary.
+
+  The billing team wants to appeal the GHP's CO-22 denial. Should they appeal?
+  If yes, draft the appeal letter and identify the supporting documentation needed.
+  If no, explain what corrective action is required instead.
+target_skills:
+  - coordination-of-benefits
+  - provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/cross/cob-denial-workup-02.yaml
+++ b/eval/prompts/cross/cob-denial-workup-02.yaml
@@ -1,0 +1,15 @@
+id: cob-denial-workup-02
+prompt: >
+  A 67-year-old active employee has Medicare (age) and an employer group health plan.
+  The employer has 35 employees. A $15,000 outpatient surgery claim was billed to
+  Medicare as primary. Medicare denied with CO-22, asserting the employer GHP should
+  pay first.
+
+  Is Medicare's CO-22 correct? Should the billing team appeal or reroute? If they
+  should appeal, provide the appeal letter and documentation checklist. If they should
+  reroute, describe the corrective billing steps.
+target_skills:
+  - coordination-of-benefits
+  - provider-denial-workup
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/cross/cob-denial-workup-03.yaml
+++ b/eval/prompts/cross/cob-denial-workup-03.yaml
@@ -1,0 +1,16 @@
+id: cob-denial-workup-03
+prompt: >
+  A 59-year-old patient is on Medicare due to disability (SSDI for 2 years) and is
+  covered under her employer's group health plan. The employer has 150 employees.
+  A $28,000 outpatient spinal decompression claim was submitted to the employer GHP
+  as primary. The GHP denied with CO-22, asserting Medicare should be primary because
+  the patient has Medicare.
+
+  Is the GHP's CO-22 correct? Should the billing team appeal or reroute? If they
+  should appeal, provide the appeal letter and documentation checklist. If they should
+  reroute, describe the corrective billing steps.
+target_skills:
+  - coordination-of-benefits
+  - provider-denial-workup
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-01.yaml
+++ b/eval/prompts/single/coordination-of-benefits-01.yaml
@@ -1,0 +1,11 @@
+id: coordination-of-benefits-01
+prompt: >
+  A 68-year-old patient is an active employee at a company with 45 employees. She has
+  both Medicare Part A and B and her employer's group health plan. A claim for an MRI
+  was submitted to Medicare first and paid $420. The employer GHP allowed $600 for the
+  same service. Which payer should have been billed first, and does Medicare need to
+  recover its payment?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-02.yaml
+++ b/eval/prompts/single/coordination-of-benefits-02.yaml
@@ -1,0 +1,10 @@
+id: coordination-of-benefits-02
+prompt: >
+  A 70-year-old retired patient has Medicare and a retiree health plan from his former
+  employer. He also recently enrolled in his spouse's active employer GHP (spouse works
+  at a company with 200 employees). For a routine colonoscopy billed at $2,200, what is
+  the correct order of benefits and why?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-03.yaml
+++ b/eval/prompts/single/coordination-of-benefits-03.yaml
@@ -1,0 +1,10 @@
+id: coordination-of-benefits-03
+prompt: >
+  A billing team submitted a workers' compensation claim to Medicare because the WC
+  carrier disputed the injury as work-related and hasn't paid after 90 days. Medicare
+  paid $1,800 as a conditional payment. The WC carrier just settled for $2,500. What
+  should the billing team do now?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-04.yaml
+++ b/eval/prompts/single/coordination-of-benefits-04.yaml
@@ -1,0 +1,10 @@
+id: coordination-of-benefits-04
+prompt: >
+  A 4-year-old dependent child is covered under both parents' employer plans. The
+  mother's birthday is March 15, 1985. The father's birthday is November 3, 1983. The
+  father's plan has covered the child since birth; the mother added the child 18 months
+  ago. Which plan is primary under NAIC COB rules and why?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-05.yaml
+++ b/eval/prompts/single/coordination-of-benefits-05.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-05
+prompt: >
+  A 66-year-old retired engineer has Medicare Parts A and B as her primary insurance and
+  a retiree group health plan through her former employer (which has 310 employees) as
+  secondary. She presents to an outpatient infusion center for IV iron therapy. Medicare
+  allows $840, pays 80% ($672), and the retiree plan allows $900. What is the correct
+  COB order for a retiree plan from a large employer, and how much is the patient
+  potentially responsible for after both payers process the claim?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-06.yaml
+++ b/eval/prompts/single/coordination-of-benefits-06.yaml
@@ -1,0 +1,11 @@
+id: coordination-of-benefits-06
+prompt: >
+  A 64-year-old patient has been on Medicare due to disability (SSDI) for 18 months.
+  His employer has 120 employees and offers a group health plan. His wife covers him on
+  her employer's GHP as well; her employer has 85 employees. A hospitalization claim
+  totaling $22,000 was submitted. Which payer is primary for MSP purposes given the
+  disability basis, and what rule governs the employer size threshold for disability MSP?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-07.yaml
+++ b/eval/prompts/single/coordination-of-benefits-07.yaml
@@ -1,0 +1,11 @@
+id: coordination-of-benefits-07
+prompt: >
+  A 58-year-old patient with end-stage renal disease (ESRD) began dialysis on
+  March 1, 2024. She has Medicare based on ESRD and is covered by her employer's GHP
+  (employer has 210 employees). It is now October 15, 2024 — 7.5 months into dialysis.
+  A nephrology office visit is billed at $275. Which payer is primary during this period,
+  and how long does the ESRD coordination period last?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-08.yaml
+++ b/eval/prompts/single/coordination-of-benefits-08.yaml
@@ -1,0 +1,11 @@
+id: coordination-of-benefits-08
+prompt: >
+  A 61-year-old patient with ESRD started dialysis on January 5, 2022. He has
+  Medicare (ESRD basis) and coverage through his spouse's employer GHP (employer has
+  500 employees). As of March 2025 — 38 months after dialysis initiation — a claim for
+  outpatient hemodialysis is submitted totaling $4,800. Has the 30-month ESRD
+  coordination period expired, and which payer is now primary?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-09.yaml
+++ b/eval/prompts/single/coordination-of-benefits-09.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-09
+prompt: >
+  A 55-year-old construction worker was injured on the job and received workers'
+  compensation coverage. He also has commercial group health insurance through his
+  union. He underwent rotator cuff repair surgery billed at $18,500. His WC carrier
+  accepted the claim. The group health plan received the claim first and paid $12,000
+  before the WC acceptance was known. What are the COB rules governing workers'
+  compensation as primary payer, and what should the group health plan do regarding its
+  conditional payment?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-10.yaml
+++ b/eval/prompts/single/coordination-of-benefits-10.yaml
@@ -1,0 +1,11 @@
+id: coordination-of-benefits-10
+prompt: >
+  A 45-year-old patient was involved in an auto accident and sustained a lumbar
+  fracture. She has no-fault auto insurance (PIP) with a $50,000 limit and a commercial
+  PPO health plan. The hospital bill totals $38,000. Her no-fault insurer has already
+  paid $22,000 toward the claim. How should the remaining $16,000 be handled between
+  the no-fault insurer and the health plan under COB rules for no-fault insurance?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-11.yaml
+++ b/eval/prompts/single/coordination-of-benefits-11.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-11
+prompt: >
+  A 52-year-old patient suffered a slip-and-fall at a grocery store and filed a
+  liability claim. She has a commercial health plan that paid $9,400 for emergency
+  surgery and follow-up care before the liability settlement was reached. The grocery
+  store's liability insurer settled for $75,000. The health plan asserted a lien for
+  its $9,400 conditional payment. Explain the health plan's right of recovery in a
+  liability settlement and whether it can recover the full $9,400 from the settlement
+  proceeds.
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-12.yaml
+++ b/eval/prompts/single/coordination-of-benefits-12.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-12
+prompt: >
+  A 40-year-old patient is covered as an employee on Plan A (her own employer) and as a
+  dependent on Plan B (her spouse's employer). Her birthday is June 14 and her spouse's
+  birthday is September 3. Both plans follow the NAIC birthday rule. She needs a knee
+  arthroscopy billed at $5,200. Which plan is primary, and what is the birthday rule
+  used to determine primary coverage for a person with dual coverage as employee and
+  dependent?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-13.yaml
+++ b/eval/prompts/single/coordination-of-benefits-13.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-13
+prompt: >
+  A 12-year-old child is covered as a dependent on both parents' employer health plans.
+  The father's birthday is April 22 and the mother's birthday is April 22 (same month
+  and day, different years — father born 1981, mother born 1983). Both plans follow the
+  NAIC birthday rule. A claim for pediatric asthma hospitalization is billed at $14,700.
+  Which plan is primary when both parents share the same birthday under the NAIC
+  birthday rule tiebreaker?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-14.yaml
+++ b/eval/prompts/single/coordination-of-benefits-14.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-14
+prompt: >
+  An 8-year-old child's parents are divorced. Per the divorce decree, the father is
+  required to carry health insurance for the child and the mother has physical custody.
+  The child is covered on both the father's Plan A and the mother's Plan B. Both plans
+  use the NAIC COB rules. The child has an appendectomy billed at $21,000. Which plan
+  is primary under the NAIC rule for children of divorced parents when a court order
+  specifies coverage responsibility?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-15.yaml
+++ b/eval/prompts/single/coordination-of-benefits-15.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-15
+prompt: >
+  A 10-year-old child has divorced parents with no court-ordered coverage requirement.
+  The custodial parent (mother, birthday November 5) has Plan A. The non-custodial
+  parent (father, birthday March 18) has Plan B. Both plans follow the NAIC COB
+  birthday rule. An urgent care visit is billed at $380. Describe the NAIC sequencing
+  for dependent children of divorced parents when there is no court order: which plan
+  is primary, secondary, and tertiary if the custodial parent has remarried and the
+  stepparent has Plan C?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-16.yaml
+++ b/eval/prompts/single/coordination-of-benefits-16.yaml
@@ -1,0 +1,11 @@
+id: coordination-of-benefits-16
+prompt: >
+  A 59-year-old patient is covered by an active employee plan through his current
+  employer and also has COBRA continuation coverage from a previous employer that he
+  elected after a job change. He needs a colonoscopy billed at $2,100. Both plans use
+  NAIC COB rules. Under NAIC, what is the priority order between active employee
+  coverage and COBRA continuation coverage, and which plan pays first?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-17.yaml
+++ b/eval/prompts/single/coordination-of-benefits-17.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-17
+prompt: >
+  A 62-year-old patient retired last year and is covered by a retiree health plan from
+  her former employer. She has not yet enrolled in Medicare (she is not yet 65 and has
+  no disability). She also has COBRA coverage from a spouse's employer plan. She
+  undergoes cardiac catheterization billed at $31,000. Under NAIC COB rules, how do
+  retiree plans and COBRA plans rank against each other in the order of benefits, and
+  which plan should be billed first?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-18.yaml
+++ b/eval/prompts/single/coordination-of-benefits-18.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-18
+prompt: >
+  A 38-year-old patient is covered as an active employee on Plan A (her own job, full
+  time) and as a dependent on Plan B (her husband's employer). Plan A uses the
+  coordination of benefits method (pay up to its allowed amount minus what primary
+  paid). Plan B uses the non-duplication method (only pays if primary paid less than
+  Plan B would have paid as primary). Plan A allowed $1,200 and paid $960 (80%). Plan
+  B's allowed amount for the same service is $1,100. Under each method, calculate how
+  much Plan B would pay as secondary payer and explain the difference.
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-19.yaml
+++ b/eval/prompts/single/coordination-of-benefits-19.yaml
@@ -1,0 +1,11 @@
+id: coordination-of-benefits-19
+prompt: >
+  A 45-year-old patient has Plan A (primary) and Plan B (secondary, non-duplication
+  method). For a physical therapy visit, Plan A allowed $150 and paid $120 (after a
+  $30 copay). Plan B's allowed amount for the same service is $110. Using the
+  non-duplication method, how much does Plan B owe as secondary, and why might Plan B
+  pay $0 in this scenario? Show the math.
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-20.yaml
+++ b/eval/prompts/single/coordination-of-benefits-20.yaml
@@ -1,0 +1,11 @@
+id: coordination-of-benefits-20
+prompt: >
+  A 35-year-old patient with dual coverage had Plan A (primary, coordination method)
+  pay $700 on a $1,000 allowed claim after applying a $300 deductible. Plan B
+  (secondary, coordination method) has a $1,050 allowed amount and a $200 deductible
+  already satisfied. What is the maximum Plan B can pay as secondary using the
+  standard coordination method, and what is the patient's final out-of-pocket?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-21.yaml
+++ b/eval/prompts/single/coordination-of-benefits-21.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-21
+prompt: >
+  A 72-year-old patient is enrolled in both Medicare Part A/B and full Medicaid
+  (QMB — Qualified Medicare Beneficiary). He is admitted for a hip replacement with a
+  total Medicare-allowed amount of $18,400. Medicare pays its portion ($14,720 after
+  the Part A deductible is applied). The hospital billed the patient for the remaining
+  $3,680. Can the hospital bill the QMB patient for Medicare cost-sharing, and what
+  is Medicaid's role as the payer of last resort in this crossover claim?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-22.yaml
+++ b/eval/prompts/single/coordination-of-benefits-22.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-22
+prompt: >
+  A 69-year-old patient has Medicare Part B and full Medicaid (non-QMB, categorically
+  needy). His physician bills $320 for an office visit. Medicare's allowed amount is
+  $185; Medicare pays $148 (80%). The physician is a Medicare/Medicaid dual-enrolled
+  provider. Medicaid's fee schedule for the same service is $90. How much can Medicaid
+  pay as secondary on this crossover claim, and can the provider balance-bill the
+  patient for the difference between Medicare's allowed and Medicaid's fee schedule?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-23.yaml
+++ b/eval/prompts/single/coordination-of-benefits-23.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-23
+prompt: >
+  A claim was denied by the secondary insurer with CARC CO-22 ("This care may be
+  covered by another payer per coordination of benefits"). The patient has Plan A
+  (primary, UnitedHealthcare) and Plan B (secondary, Aetna). The provider submitted
+  the claim to Aetna without first billing UnitedHealthcare. What steps should the
+  billing team take to resolve the CO-22 denial, what documentation must be submitted
+  to Aetna, and within what timeframe should the corrected claim be resubmitted?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-24.yaml
+++ b/eval/prompts/single/coordination-of-benefits-24.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-24
+prompt: >
+  A provider receives an 835 ERA showing CARC OA-23 ("The impact of prior payer(s)
+  adjudication including payments and/or adjustments") on a secondary claim. The
+  primary EOB shows Plan A allowed $950, applied a $200 deductible, and paid $600.
+  Plan B (secondary, coordination method) received the claim but the 835 shows a $0
+  payment with OA-23. The billed charge was $1,400. What does OA-23 indicate about
+  how secondary payment was calculated, and what should the billing team verify to
+  determine whether Plan B's $0 payment is correct?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-25.yaml
+++ b/eval/prompts/single/coordination-of-benefits-25.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-25
+prompt: >
+  A 67-year-old patient elected COBRA continuation coverage after retiring early in
+  January 2024. In April 2024 he turned 65 and became eligible for Medicare Part A
+  and B but did not enroll, thinking COBRA was sufficient. In October 2024 he is
+  hospitalized for a STEMI with a $95,000 claim. The COBRA plan now denies the claim
+  arguing Medicare should be primary. Is COBRA the plan required to pay first when a
+  COBRA-covered individual is also Medicare-eligible, and what are the MSP implications
+  for this patient's failure to enroll in Medicare?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-26.yaml
+++ b/eval/prompts/single/coordination-of-benefits-26.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-26
+prompt: >
+  A 63-year-old patient with ESRD began dialysis on June 1, 2022. She was covered by
+  her employer's GHP (employer has 180 employees) and Medicare (ESRD basis). In
+  November 2024 — 29 months after dialysis started — she also turns 65 and becomes
+  eligible for Medicare based on age. Her employer plan is still active. Which Medicare
+  entitlement basis governs COB at month 29, and does turning 65 during the ESRD
+  coordination period change which payer is primary?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-27.yaml
+++ b/eval/prompts/single/coordination-of-benefits-27.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-27
+prompt: >
+  A 70-year-old Medicare beneficiary works full time at a company with 18 employees
+  and has the employer's GHP. His employer is not subject to MSP working-aged rules
+  because the company has fewer than 20 employees. Medicare paid $5,600 on a cataract
+  surgery claim. The small-employer GHP then paid an additional $400. Was Medicare
+  correct to pay primary here, and what are the obligations of the small employer GHP
+  when Medicare is primary for a working-aged employee?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-28.yaml
+++ b/eval/prompts/single/coordination-of-benefits-28.yaml
@@ -1,0 +1,12 @@
+id: coordination-of-benefits-28
+prompt: >
+  A 69-year-old active employee works at a company that employs 95 workers. He has
+  both Medicare and the employer GHP. He is also disabled (SSDI for 3 years) in
+  addition to being working-aged. The employer has exactly 95 employees. A claim for
+  lumbar spinal fusion is billed at $62,000. Under the MSP rules, which employer size
+  threshold governs — the 20-employee working-aged threshold or the 100-employee
+  disability threshold — and which payer is primary?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-29.yaml
+++ b/eval/prompts/single/coordination-of-benefits-29.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-29
+prompt: >
+  A Medicare beneficiary settled a workers' compensation claim for a back injury in
+  March 2024 for $120,000, with $40,000 allocated to future medical expenses (a Workers'
+  Compensation Medicare Set-Aside, WCMSA). Medicare had previously made conditional
+  payments of $18,500 for injury-related care. The settlement did not initially account
+  for Medicare's conditional payment. Describe Medicare's right to recover its $18,500
+  in conditional payments from this WC settlement and the timeline and process for
+  resolution through the BCRC.
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-30.yaml
+++ b/eval/prompts/single/coordination-of-benefits-30.yaml
@@ -1,0 +1,15 @@
+id: coordination-of-benefits-30
+prompt: >
+  A provider's billing department discovers that a patient treated in 2023 was
+  enrolled in Medicare based on disability throughout 2023, but the patient's
+  employer had 60 employees. The billing team had mistakenly billed the employer
+  GHP as primary and Medicare as secondary the entire year. Medicare paid secondary
+  on 14 claims totaling $47,000 in Medicare payments; the GHP paid primary. The
+  error is discovered in mid-2025. Describe the retroactive MSP correction process:
+  what must the provider do to reverse the incorrect claim order, how does Medicare
+  recover its conditional payments, and what is the lookback period for retroactive
+  MSP adjustments?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-31.yaml
+++ b/eval/prompts/single/coordination-of-benefits-31.yaml
@@ -1,0 +1,14 @@
+id: coordination-of-benefits-31
+prompt: >
+  A patient was covered under Plan A (employer GHP) through March 31. She started a new
+  job April 15 and enrolled in Plan B effective April 15. There is a 15-day gap in coverage.
+  She had a surgery on April 10 (still under Plan A) and a follow-up visit on April 22
+  (now under Plan B only). The hospital billed both dates of service to Plan B because
+  that was the most recent plan on file.
+
+  What is the correct payer for each date of service, and how should the billing team correct
+  the claims?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: medium

--- a/eval/prompts/single/coordination-of-benefits-32.yaml
+++ b/eval/prompts/single/coordination-of-benefits-32.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-32
+prompt: >
+  A patient is the subscriber on his own employer plan (Plan A). He is also covered as
+  a dependent on his spouse's employer plan (Plan B). Both plans have COB provisions.
+  The billing team assumed Plan A is primary because he is the subscriber. The claim was
+  denied by Plan A with CO-22, suggesting another plan may be primary.
+
+  Is the billing team's assumption correct? Which plan is actually primary under NAIC
+  COB rules, and why?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: easy

--- a/eval/prompts/single/coordination-of-benefits-33.yaml
+++ b/eval/prompts/single/coordination-of-benefits-33.yaml
@@ -1,0 +1,15 @@
+id: coordination-of-benefits-33
+prompt: >
+  A patient was covered under Plan A (employer) through June 30 and enrolled in Plan B
+  (new employer) effective June 1, creating a 30-day overlap. During the overlap period
+  (June 1–30) he had three physical therapy visits. Both plans are active for those dates.
+
+  Plan A is billed and pays. Plan B denies all three claims with CO-22, stating Plan A
+  should be primary. The billing team argues Plan B should be primary because the patient
+  was actively employed at the new job.
+
+  Who is correct, and what is the right COB order for the overlap period?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/eval/prompts/single/coordination-of-benefits-34.yaml
+++ b/eval/prompts/single/coordination-of-benefits-34.yaml
@@ -1,0 +1,13 @@
+id: coordination-of-benefits-34
+prompt: >
+  A patient is 58 years old and on Medicare due to disability. She is actively
+  employed and covered under her employer's group health plan. The employer has
+  80 employees. The claim was denied by Medicare with CO-22, indicating another
+  payer may be primary.
+
+  Is Medicare's CO-22 denial correct? Which payer is actually primary, and what
+  steps should the billing team take to resolve this?
+target_skills:
+  - coordination-of-benefits
+domain: healthcare-ops
+difficulty: hard

--- a/skills/coordination-of-benefits/README.md
+++ b/skills/coordination-of-benefits/README.md
@@ -1,0 +1,88 @@
+# Coordination of Benefits — Skill
+
+## What this adds
+
+A reasoning skill for **Coordination of Benefits (COB)** — the rules that determine which insurer pays first when a patient has multiple plans. This is one of the most common sources of claim denials in healthcare billing, appearing as CO-22 denials across Medicare and commercial payers.
+
+The skill covers two frameworks:
+
+- **Medicare Secondary Payer (MSP)** — federal rules that determine when Medicare is *not* the primary payer. The default assumption in billing is "Medicare pays first," but MSP overrides that when an employer plan, workers' comp, or auto insurer should pay first instead. Getting this wrong is a federal compliance violation with potential penalty exposure.
+- **NAIC commercial COB** — order-of-benefits rules for patients with two commercial plans: birthday rule, subscriber vs. dependent, active vs. COBRA, duration tiebreaker.
+
+The skill also covers coordination math (standard COB, non-duplication, Medicaid lesser-of) and CO-22/CO-23 denial resolution.
+
+---
+
+## Why COB needs a skill
+
+COB has a well-defined rule set (CMS MSP Manual, NAIC Model 120, 42 CFR §411) but baseline models fail on it in a predictable way: they know the rules exist but misapply thresholds and edge cases that are extremely common in practice.
+
+The specific failure modes our eval confirmed:
+
+| Scenario | Baseline failure | Skill fix |
+|---|---|---|
+| Disability patient, employer < 100 | Applies 20-employee working-aged threshold | Correctly applies 100-employee disability threshold |
+| Both plans active simultaneously (job overlap) | Applies "active beats COBRA" rule | Skips to longer-coverage tiebreaker |
+| Patient turns 65 during ESRD coordination period | Resets COB order at age 65 | Correctly continues ESRD rules through the 30-month window |
+| Dual entitlement (age 65 + disability) | Invents a "most restrictive threshold" rule | Evaluates each MSP basis independently; working-aged governs |
+| Medicaid as secondary, Medicare paid more than Medicaid's fee schedule | Flags $0 Medicaid payment as an error | Correctly applies lesser-of rule, flags balance billing prohibition |
+
+These aren't obscure edge cases — they are the exact scenarios that generate CO-22 denials on a billing team's desk. A wrong answer isn't just unhelpful; it creates MSP violations, conditional payment recovery demands, and ping-pong denials between payers.
+
+---
+
+## Why this is a skill, not a lookup
+
+COB can't be solved with RAG or a knowledge base because the user presents a novel fact pattern each time (different Medicare basis, different employer size, different denying payer). The skill has to apply rules to facts — it's a reasoning problem, not a retrieval problem. This is the category of problem where skills outperform baseline most reliably.
+
+---
+
+## Eval results
+
+### Single-skill: 34 prompts, easy through hard
+
+| Metric | Value |
+|---|---|
+| Win rate | 97.1% (33/34) |
+| Cohen's d | +1.28 (large) |
+| Delta | +11.8 |
+| Skill activation | 34/34 |
+
+| Dimension | Win Rate | Cohen's d |
+|---|---|---|
+| critical_thinking | 98.5% | +1.66 |
+| actionability | 98.5% | +1.32 |
+| relevance | 92.6% | +1.10 |
+| scientific_accuracy | 80.9% | +0.76 |
+| coherence | 89.7% | +0.63 |
+
+### Cross-skill (COB + provider-denial-workup): 3 prompts
+
+| Metric | Value |
+|---|---|
+| Win rate | 100% |
+| Cohen's d | +7.56 (large) |
+| critical_thinking d | +5.00 |
+
+The cross-skill prompts test the natural workflow: a CO-22 denial arrives, COB reasoning determines whether the denial is correct or an error, and denial-workup determines posture (OVERTURN and draft appeal, or reroute with corrective billing steps).
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **COB** | Coordination of Benefits — rules governing how multiple insurers split the bill |
+| **MSP** | Medicare Secondary Payer — federal law governing when Medicare is not primary |
+| **ESRD** | End-Stage Renal Disease — kidney failure requiring dialysis or transplant; a separate Medicare eligibility basis with its own 30-month coordination period |
+| **NAIC** | National Association of Insurance Commissioners — sets Model Regulation 120 governing commercial COB order-of-benefits |
+| **GHP** | Group Health Plan — employer-sponsored insurance |
+| **CARC** | Claim Adjustment Reason Code — standardized denial code; CO-22 = "another payer may be primary" |
+
+---
+
+## Files
+
+- `SKILL.md` — skill definition
+- `../../eval/prompts/single/coordination-of-benefits-01..34.yaml` — 34 single-skill eval prompts
+- `../../eval/prompts/cross/cob-denial-workup-01..03.yaml` — 3 cross-skill prompts (COB + denial-workup)

--- a/skills/coordination-of-benefits/README.md
+++ b/skills/coordination-of-benefits/README.md
@@ -33,7 +33,8 @@ These aren't obscure edge cases — they are the exact scenarios that generate C
 
 ## Why this is a skill, not a lookup
 
-COB can't be solved with RAG or a knowledge base because the user presents a novel fact pattern each time (different Medicare basis, different employer size, different denying payer). The skill has to apply rules to facts — it's a reasoning problem, not a retrieval problem. This is the category of problem where skills outperform baseline most reliably.
+COB can't be solved with RAG or a knowledge base because the user presents a novel fact pattern each time (different Medicare basis, different employer size, different denying payer). The skill has to apply rules to facts — it's a reasoning problem, not a retrieval problem. 
+This is the category of problem where skills outperform baseline most reliably.
 
 ---
 
@@ -85,4 +86,5 @@ The cross-skill prompts test the natural workflow: a CO-22 denial arrives, COB r
 
 - `SKILL.md` — skill definition
 - `../../eval/prompts/single/coordination-of-benefits-01..34.yaml` — 34 single-skill eval prompts
-- `../../eval/prompts/cross/cob-denial-workup-01..03.yaml` — 3 cross-skill prompts (COB + denial-workup)
+- `../../eval/prompts/cross/cob-denial-workup-01..03.yaml` — 3 cross-skill prompts (COB + provider-denial-workup)
+

--- a/skills/coordination-of-benefits/SKILL.md
+++ b/skills/coordination-of-benefits/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: coordination-of-benefits
+description: "Reasoning skill for Coordination of Benefits (COB) determination in healthcare claims. Use when a claim involves multiple insurers and the user needs to know which plan pays first, how to sequence billing, or why a COB-related denial or underpayment occurred. Covers Medicare Secondary Payer (MSP) rules and NAIC commercial COB order-of-benefits logic. Triggers include \"coordination of benefits\", \"COB\", \"Medicare secondary payer\", \"MSP\", \"which insurance is primary\", \"birthday rule\", \"primary payer\", \"secondary payer\", \"COB denial\", \"working aged\", \"ESRD coordination\", \"disability MSP\", \"workers comp primary\", \"no-fault primary\", \"auto insurance primary\", \"COB order of benefits\", \"dual coverage\", \"double coverage\", \"two insurances\", \"secondary billing\", \"crossover claim\", \"COB adjustment\", \"non-duplication\", \"benefits coordination error\"."
+usage: Invoke when a claim has multiple insurers and the user needs to determine primary/secondary order, compute secondary payment, or resolve a COB denial.
+version: 1.0.0
+tags: [skill, category:reasoning, revenue-cycle, cob, msp, hcls]
+---
+
+# Coordination of Benefits (COB) — Reasoning Skill
+
+## When to Use
+
+- A patient has two or more insurance plans and the user needs to know which pays first
+- A claim was denied or underpaid with a COB-related reason code (CO-22, OA-22, CO-23, OA-23, CO-25)
+- A Medicare claim needs MSP screening before billing Medicare
+- A biller is sequencing a crossover claim (Medicare → Medicaid or Medicare → secondary commercial)
+
+---
+
+## Response Format
+
+Structure each response in this order:
+
+1. **Scenario** — identify which COB framework applies (MSP or NAIC commercial) and why
+2. **Order of Benefits** — state primary payer and secondary payer with the specific rule that governs it
+3. **Coordination Math** — what the secondary owes, using the correct method (coordination vs non-duplication)
+4. **Billing Sequence** — exact steps to bill each payer in order
+5. **Flags** — any deadlines, documentation requirements, or common mistakes for this scenario
+
+Do not narrate the decision tree traversal. Present only the conclusion with the governing rule cited.
+Target: 200–350 words for analysis; include full billing sequence when requested.
+
+---
+
+## Guardrails
+
+- **No fabrication** — if the patient's plan documents or contract terms are unknown, flag as `[verify with plan document]`
+- **MSP takes precedence** — when Medicare is involved, always screen for MSP first; commercial COB rules only apply when Medicare is not a payer
+- **State variation** — NAIC Model 120 is the baseline; individual states may vary. Flag: `[verify state-specific COB rules if claim is in a non-conforming state]`
+- **Medicaid is always last** — Medicaid is payer of last resort by federal law; never bill Medicaid before all other insurers
+- **Date of service governs payer, not the most recent plan on file** — when a patient changes coverage mid-treatment, the plan active on the date of service is the correct payer for that claim. Always verify coverage effective and termination dates against each DOS. Billing the current active plan for a DOS that falls under a prior plan is a COB error regardless of what is in the system at billing time
+
+---
+
+## Framework Selection
+
+```
+Does the patient have Medicare?
+├─ YES → Apply Medicare Secondary Payer (MSP) rules first
+│   └─ Is there also a commercial secondary? → Apply coordination math after MSP
+└─ NO → Apply NAIC commercial COB order-of-benefits rules
+    └─ Is one plan Medicaid? → Medicaid always pays last regardless of other rules
+```
+
+---
+
+## Core Procedure
+
+Follow these steps in order for every COB determination:
+
+1. **Identify all payers** — list every insurance plan the patient carries: commercial, Medicare, Medicaid, Medicare Advantage, TRICARE, workers' comp, no-fault auto. A missed payer is the #1 COB error.
+2. **Screen for Medicare** — if Medicare is one of the payers, apply MSP rules before any commercial COB rules. MSP always takes precedence.
+3. **Obtain MSP questionnaire status** — for Medicare patients, verify whether an MSP questionnaire was completed at registration. If not on file, ask the user before proceeding; do not assume Medicare is primary.
+4. **Handle unknown MSP status** — if MSP status cannot be confirmed: flag as `[MSP status unverified — complete CMS MSP questionnaire before billing]` and default to billing the commercial plan first as a precaution.
+5. **Apply MSP scenario table** — match the patient's situation to one of the 10 MSP scenarios using employer size, Medicare basis (age/disability/ESRD), and injury type.
+6. **Check for retroactive MSP** — if Medicare already paid and a primary payer is later identified, Medicare must recover its conditional payment. Flag this scenario: `[Conditional payment recovery required — notify MSP Recovery Contractor]`.
+7. **Apply NAIC commercial COB rules** — if Medicare is not involved, work through the 7 order-of-benefits rules in sequence (subscriber vs dependent → birthday rule → active vs retired → duration tiebreaker).
+8. **Determine COB math method** — read the secondary plan's COB provision for "non-duplication" or "maintenance of benefits" language. If found → Method 2. If standard COB language or unclear → Method 1.
+9. **Compute secondary payment** — apply the correct method (coordination or non-duplication) per Part 3 below. Show the math explicitly.
+10. **Identify required documentation** — for each payer in sequence: primary EOB (required for secondary submission), MSP questionnaire (required for Medicare secondary claims), accident report (required for WC/no-fault), court order (required for divorced-parent dependent child claims).
+11. **Sequence the billing** — bill primary first, wait for EOB, then submit to secondary with primary EOB attached. Never submit to secondary before primary responds.
+12. **Check Medicaid last** — if Medicaid is one of the payers, bill it last regardless of any other rule. Attach all prior EOBs.
+13. **Resolve COB denials** — map the CARC to the COB Denial table in Part 4; follow the specific resolution path for that code.
+14. **Flag crossover claim handling** — for Medicare/Medicaid crossovers, confirm whether the state uses automatic crossover forwarding. If yes, do not bill Medicaid separately; if no, submit manually with Medicare EOB.
+15. **Document the determination** — record the COB order determination and the rule that governs it in the claim notes for audit trail purposes.
+
+---
+
+### Part 1 — Medicare Secondary Payer (MSP)
+
+MSP rules determine when Medicare is NOT the primary payer. When any of the following scenarios apply, the other payer must be billed first.
+
+#### MSP Scenario Table
+
+| Scenario | Condition | Primary Payer | Medicare Status |
+|---|---|---|---|
+| Working aged | Patient 65+, employer has **≥20 employees**, active employee or spouse | Employer group health plan (GHP) | Secondary |
+| Working aged — small employer | Patient 65+, employer has **<20 employees**, active employee or spouse | Medicare | Primary |
+| Disability | Patient <65, disabled, employer has **≥100 employees** | Employer GHP | Secondary |
+| Disability — small employer | Patient <65, disabled, employer has **<100 employees** | Medicare | Primary |
+| ESRD — coordination period | End-Stage Renal Disease, first **30 months** after Medicare entitlement begins (entitlement starts the **4th month of dialysis** for regular dialysis patients, or month of kidney transplant) | Employer GHP (if active coverage exists) | Secondary |
+| ESRD — after coordination period | After 30-month coordination period | Medicare | Primary |
+| ESRD — patient turns 65 during/after coordination period | Patient has ESRD Medicare entitlement and reaches age 65 while also covered by a GHP | **During** coordination period: GHP primary (ESRD rules still govern). **After** coordination period: apply working-aged MSP rules — if employer ≥20 employees, GHP is primary again under working-aged rules. Turning 65 does **not** reset the 30-month clock, but once the coordination period ends, working-aged rules take over if the patient is still an active employee. | Depends on employer size and whether coordination period has ended |
+| No-fault insurance | Injury covered by auto no-fault policy | No-fault insurer | Secondary |
+| Workers' compensation | Work-related injury or illness | Workers' comp carrier | Secondary — **never bill Medicare first for WC claims** |
+| Liability insurance | Third-party liability (auto accident, slip-and-fall) | Liability insurer | Secondary |
+| Veterans benefits | VA-covered condition | VA | Secondary — only if treatment at non-VA facility for non-VA condition |
+| COBRA | Patient on COBRA, also has Medicare due to disability | Medicare | Primary (COBRA is secondary when Medicare is due to disability) |
+
+**Key MSP thresholds:**
+- Working aged employer size: **≥20 employees** = GHP primary
+- Disability employer size: **≥100 employees** = GHP primary
+- ESRD coordination period: **30 months** from first Medicare entitlement date (not ESRD onset). `[Verify exact start date against CMS MSP Manual Publication 100-05 — some CMS guidance places the start at the first month of dialysis rather than the 4th month entitlement date]`
+- **ESRD employer size is irrelevant during the coordination period** — unlike working-aged and disability MSP, the ESRD 30-month coordination rule applies regardless of employer size. Do not cite employer size as a factor in ESRD COB order during the coordination period.
+- MSP verification source: CMS MSP Manual, Publication 100-05, Chapter 2 — verify current version
+
+**Dual entitlement (age + disability simultaneously):** When a patient is both 65+ and disabled (SSDI), evaluate each MSP provision independently — do NOT apply a "most restrictive" or "higher threshold" rule. Working-aged rules govern when the patient is an active employee. Example: patient age 69, disabled, employer has 95 employees → working-aged threshold (≥20) = GHP primary; disability threshold (≥100) = Medicare primary. Because the patient is working-aged and the employer meets the ≥20 threshold, **working-aged rules control and GHP is primary**. The disability provision is irrelevant once working-aged rules establish GHP primacy. `[Verify with CMS MSP Manual Publication 100-05 for current dual-entitlement guidance]`
+
+#### MSP Decision Tree
+
+```
+Is the patient 65 or older with an active employer GHP?
+├─ YES
+│   ├─ Employer has ≥20 employees? → GHP primary, Medicare secondary
+│   └─ Employer <20 employees? → Medicare primary, GHP secondary (Medicare SELECT)
+└─ NO
+    ├─ Patient disabled (under 65) with employer GHP?
+    │   ├─ Employer ≥100 employees? → GHP primary, Medicare secondary
+    │   └─ Employer <100 employees? → Medicare primary
+    ├─ Patient has ESRD?
+    │   ├─ Calculate 30-month period from Medicare entitlement date (4th month of dialysis, not diagnosis date)
+    │   ├─ Within 30-month coordination period? → GHP primary (if GHP exists)
+    │   └─ After 30 months? → Medicare primary regardless of employer size
+    └─ Injury involved?
+        ├─ Workers' comp? → WC carrier primary, never bill Medicare first
+        ├─ No-fault auto? → No-fault insurer primary
+        └─ Liability? → Liability insurer primary (conditional payment rules apply)
+```
+
+**Conditional payment warning:** For liability, no-fault, and WC claims, Medicare may make conditional payments while the primary payer case is pending. When the primary payer settles, Medicare must be reimbursed via the Benefits Coordination & Recovery Center (BCRC). **Do not cite specific BCRC phone numbers, form numbers, or MMSEA Section 111 reporting deadlines in responses** — these change and must be verified at cms.gov/medicare/coordination-of-benefits-and-recovery before acting. Flag: `[Verify current BCRC contact and reporting requirements at cms.gov]`.
+
+---
+
+### Part 2 — NAIC Commercial COB (Non-Medicare)
+
+When Medicare is not involved, apply NAIC Model 120 order-of-benefits rules.
+
+#### Order of Benefits Rules (apply in sequence — first rule that applies controls)
+
+| Priority | Rule | Primary Plan |
+|---|---|---|
+| 1 | Non-COB plan | A plan with no COB provision always pays first |
+| 2 | Patient is not a dependent | The plan covering the patient as an **employee/subscriber** pays before the plan covering them as a dependent |
+| 3 | Dependent child — parents not separated | Plan of the parent whose **birthday falls earlier in the calendar year** (birthday rule — month and day only, not year) |
+| 4 | Dependent child — parents separated/divorced | Plan of the parent with **court-ordered financial responsibility** pays first; if no court order, custodial parent's plan; then stepparent of custodial parent; then non-custodial parent |
+| 5 | Active employee vs. retired/COBRA | **Active employee** plan is primary. **Retired/inactive employee** plan is secondary to active but **primary over COBRA/continuation**. COBRA is always last among these three. **This rule only applies when one plan covers the patient as an active employee and the other as an inactive/retired/COBRA enrollee. When both plans cover the patient as an active employee simultaneously, skip to Rule 6.** |
+| 6 | Longer continuous coverage | Plan covering the patient **longer** pays first (tiebreaker) |
+| 7 | Equal duration | Plans share costs 50/50 if all else equal |
+
+**Retired vs COBRA distinction:** A retiree plan and a COBRA plan are not equivalent. A retiree plan (ongoing coverage from former employer as a benefit) is primary over a COBRA plan (temporary continuation coverage). Order: Active employee → Retiree/inactive → COBRA.
+
+**Dual active-employment overlap:** When a patient is actively employed at two jobs simultaneously and both employer plans are active for the same dates of service, Rule 5 does not apply — neither plan is continuation or inactive coverage. Apply Rule 6 directly: the plan that has covered the patient longer is primary. This scenario arises when a patient changes jobs with overlapping coverage periods (e.g., old plan active through June 30, new plan effective June 1 — during June 1–30 both are active-employment plans and the longer-coverage rule governs).
+
+**Birthday rule detail:** If both parents have the same birthday (month and day), the plan that covered the parent longer pays first. The rule is based on calendar birthday, not age — a younger parent with a January 1 birthday is primary over an older parent with a December 31 birthday.
+
+**Gender rule:** Some older plans used the gender rule (father's plan primary). NAIC Model 120 replaced this with the birthday rule. If a plan still uses the gender rule, it violates NAIC guidelines — flag for the patient to contest.
+
+---
+
+### Part 3 — Coordination Math
+
+#### Method 1: Coordination of Benefits (Standard — most commercial plans)
+
+Secondary pays the lesser of:
+- Its own allowed amount minus what the primary paid, OR
+- The patient's out-of-pocket cost after primary payment (copay + coinsurance + deductible)
+
+```
+Example:
+Billed:           $1,000
+Primary allowed:  $800  →  Primary pays $640 (80%), patient owes $160
+Secondary allowed: $850
+Secondary pays:   min($850 − $640, $160) = min($210, $160) = $160
+Patient owes:     $0
+```
+
+#### Method 2: Non-Duplication (some commercial plans — check plan document)
+
+Secondary pays only if its own benefit exceeds what the primary already paid. It pays the difference up to its own benefit — but only if primary paid less than the secondary would have paid alone.
+
+```
+Example:
+Primary pays $640 on a $800 allowed claim (80%)
+Secondary allows $850, would pay $680 alone (80%)
+Secondary pays: $680 − $640 = $40
+```
+
+**Non-duplication is less generous to the patient.** If the primary paid more than the secondary would have paid alone, the secondary pays $0.
+
+**How to tell which method applies:** Read the secondary plan's COB provision. "Non-duplication" or "maintenance of benefits" language = Method 2. Standard COB language = Method 1. When in doubt, assume Method 1.
+
+#### Method 3: Medicaid as Secondary — Lesser-of Rule
+
+When Medicaid is secondary (always payer of last resort), most states apply the **lesser-of** methodology:
+
+Medicaid pays the **lesser of**:
+- Its own fee schedule amount minus what the primary already paid, OR
+- $0 if the primary already paid ≥ Medicaid's fee schedule amount
+
+```
+Example:
+Medicare (primary) paid:   $148
+Medicaid fee schedule:     $90
+Medicaid pays:             max($90 − $148, $0) = $0
+Patient owes:              $0 (balance billing prohibited for Medicaid patients)
+```
+
+**Key rule:** If Medicare (or any primary payer) has already paid more than Medicaid's fee schedule, Medicaid pays $0. This is not an error — it is the correct outcome under the lesser-of rule. Do not bill the patient the difference; balance billing Medicaid patients is prohibited by federal law.
+
+`[Verify state-specific Medicaid lesser-of methodology — some states use cost-sharing or supplemental payment rules that differ]`
+
+#### Medicare as Secondary — Crossover Claims
+
+When Medicare is secondary (MSP applies):
+1. Bill primary payer first; obtain remittance
+2. Submit crossover claim to Medicare with primary's EOB attached
+3. Medicare pays up to its allowed amount minus what primary paid
+4. Medicare does **not** pay more than its own allowed amount total
+5. For Medicare/Medicaid crossover: Medicare forwards claim automatically to Medicaid in most states — do not bill Medicaid separately
+
+---
+
+### Part 4 — COB Denial Resolution
+
+| CARC | Description | Root Cause | Resolution |
+|---|---|---|---|
+| CO-22 | This care may be covered by another payer | Payer believes another plan is primary | Provide MSP questionnaire result or primary EOB |
+| OA-22 | Same as CO-22 | Same | Same |
+| CO-23 | Payment adjusted due to COB | COB applied — payment reduced | Verify coordination math; dispute if secondary calculation is wrong |
+| OA-23 | Same as CO-23 | Same | Same |
+| CO-25 | Payment denied — payment made by another payer | Duplicate payment concern | Provide remittance showing no duplicate; resubmit |
+
+---
+
+## Common Mistakes
+
+- **Wrong:** Applying the 20-employee threshold for a disability-based Medicare patient.
+  **Right:** The 20-employee threshold applies only to working-aged (65+) MSP. For disability-based Medicare, the threshold is **100 employees**. An employer with 80 employees makes Medicare primary for a disabled patient under 65, but secondary for a working-aged patient 65+.
+
+- **Wrong:** Billing Medicare first for a working-aged patient whose employer has 80 employees.
+  **Right:** The employer GHP is primary. Bill GHP first, then Medicare. Billing Medicare first creates an MSP violation and Medicare will recover the conditional payment.
+
+- **Wrong:** Applying the birthday rule by age (older parent = primary).
+  **Right:** Birthday rule uses calendar date (month and day) — earlier in the year = primary, regardless of which parent is older.
+
+- **Wrong:** Billing Medicaid before a commercial secondary payer.
+  **Right:** Medicaid is always payer of last resort by federal law (42 CFR §433.139). Bill all other payers first.
+
+- **Wrong:** Assuming ESRD coordination period starts at diagnosis.
+  **Right:** The 30-month period starts at the **first month of Medicare entitlement** due to ESRD — not at diagnosis or dialysis start.
+
+- **Wrong:** Using non-duplication math when the plan uses standard COB.
+  **Right:** Check the plan document for "non-duplication" or "maintenance of benefits" language. Default to standard coordination method if unclear.
+
+- **Wrong:** Billing Medicare for a workers' comp claim before WC settles.
+  **Right:** WC is always primary. Medicare may make conditional payments but must be reimbursed when WC settles. Document all conditional payments.
+
+- **Wrong:** Applying the gender rule (father's plan primary) for dependent children.
+  **Right:** NAIC Model 120 replaced the gender rule with the birthday rule in all conforming states. Flag if a payer is still applying the gender rule.
+
+- **Wrong:** Assuming the longer-coverage tiebreaker applies before checking active vs. retired status.
+  **Right:** Active employee plan always beats retired/COBRA plan — apply that rule before the duration tiebreaker.
+
+- **Wrong:** Applying the active-employee-beats-COBRA rule when both plans are active-employment plans.
+  **Right:** Rule 5 (active vs. retired/COBRA) only fires when one plan is genuinely continuation or inactive coverage. When a patient is actively employed at two employers simultaneously and both plans are active for the same dates, skip Rule 5 entirely and apply Rule 6: the plan covering the patient longer is primary.
+
+- **Wrong:** Applying a "most restrictive" or "higher threshold" rule when a patient has dual Medicare entitlement (age + disability).
+  **Right:** Evaluate each MSP provision independently. Working-aged rules govern for an active employee 65+. If the employer meets the ≥20 working-aged threshold, GHP is primary regardless of disability status or the 100-employee disability threshold.
+
+- **Wrong:** Citing Form CMS-L564 as the MSP questionnaire.
+  **Right:** Form CMS-L564 is the Request for Employment Information used for Medicare Part B enrollment, not the MSP questionnaire. The MSP questionnaire is a separate CMS intake form completed at registration to determine MSP status. `[Verify current MSP questionnaire form number at cms.gov]`
+
+---
+
+## Quick Reference: MSP Employer Size Thresholds
+
+| Medicare Basis | GHP Primary Threshold | Medicare Primary When |
+|---|---|---|
+| Age 65+ (working aged) | ≥20 employees | <20 employees |
+| Disability (under 65) | ≥100 employees | <100 employees |
+| ESRD | Any size — first 30 months | After 30-month period |
+
+**Sources:**
+- CMS MSP Manual, Publication 100-05 — verify current version at cms.gov
+- NAIC Coordination of Benefits Model Regulation, Model 120 — verify state adoption at content.naic.org/model-laws
+- 42 CFR §433.139 — Medicaid payer of last resort
+- 42 CFR §411 — Medicare Secondary Payer statute


### PR DESCRIPTION
Reasoning skill for COB determination — covers Medicare Secondary Payer (MSP) rules and NAIC commercial order-of-benefits logic. Targets CO-22 denials, which are among the most common billing errors in revenue cycle.

Baseline models know COB rules exist but consistently misapply thresholds on edge cases (disability vs. working-aged employer size, dual-entitlement, ESRD coordination period, Medicaid lesser-of). This skill encodes the decision tree explicitly.

Eval: 97.1% win rate, d=+1.28 (large), 34 prompts. Cross-skill eval with provider-denial-workup: 100% win rate, d=+7.56.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
